### PR TITLE
Coerced username to lowercase, to address bug #8

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,7 +106,7 @@ the chat.
                 enable_audio=True,
                 verbose=False) as videostream, \
             TwitchChatStream(
-                username=args.username,
+                username=args.username.lower(),  # Must provide a lowercase username.
                 oauth=args.oauth,
                 verbose=False) as chatstream:
 


### PR DESCRIPTION
Per Issue #8, if username is not all lowercase, `TwitchChatStream` cannot send messages.

This changes the example to coerce the username to lowercase so no one gets tripped up by it.
