### PR TITLE
Fixed bug trying to decode a str.

### DIFF
--- a/twitchstream/chat.py
+++ b/twitchstream/chat.py
@@ -229,7 +229,7 @@ class TwitchChatStream(object):
                                       data)[0],
                 'username': re.findall(r'^:([a-zA-Z0-9_]+)!', data)[0],
                 'message': re.findall(r'PRIVMSG #[a-zA-Z0-9_]+ :(.+)',
-                                      data)[0].decode('utf8')
+                                      data)[0]
             }
         else:
             return None


### PR DESCRIPTION
I've run the example script on two machines now and it's pretty great.

Each time however I've had to make this change to get them to not crash when someone tries to give a color in the chat.

Otherwise everything is fine so have a nice day!

I'm using Python 3.9+

```bash
File "/app/main.py", line 55, in <module>

    received = chatstream.twitch_receive_messages()

File "/app/.heroku/python/lib/python3.9/site-packages/twitchstream/chat.py", line 268, in twitch_receive_messages

     rec = [self._parse_message(line)

File "/app/.heroku/python/lib/python3.9/site-packages/twitchstream/chat.py", line 268, in <listcomp>

     rec = [self._parse_message(line)

File "/app/.heroku/python/lib/python3.9/site-packages/twitchstream/chat.py", line 231, in _parse_message

     'message': re.findall(r'PRIVMSG #[a-zA-Z0-9_]+ :(.+)',

AttributeError: 'str' object has no attribute 'decode'
```